### PR TITLE
ignite-1241-dev: fixed failure timeout warning when only client is connected

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -628,9 +628,9 @@ class ServerImpl extends TcpDiscoveryImpl {
     }
 
     /** {@inheritDoc} */
-    @Override protected void onDataReceived() {
+    @Override protected void onMessageExchanged() {
         if (spi.failureDetectionTimeoutEnabled() && locNode != null)
-            locNode.lastDataReceivedTime(U.currentTimeMillis());
+            locNode.lastExchangeTime(U.currentTimeMillis());
     }
 
     /**
@@ -1916,9 +1916,13 @@ class ServerImpl extends TcpDiscoveryImpl {
             if (spi.ensured(msg))
                 msgHist.add(msg);
 
-            if (msg.senderNodeId() != null && !msg.senderNodeId().equals(getLocalNodeId()))
-                // Reset the flag.
+            if (msg.senderNodeId() != null && !msg.senderNodeId().equals(getLocalNodeId())) {
+                // Received a message from remote node.
+                onMessageExchanged();
+
+                // Reset the failure flag.
                 failureThresholdReached = false;
+            }
 
             spi.stats.onMessageProcessingFinished(msg);
         }
@@ -2277,6 +2281,8 @@ class ServerImpl extends TcpDiscoveryImpl {
                                 spi.stats.onMessageSent(msg, U.currentTimeMillis() - tstamp);
 
                                 int res = spi.readReceipt(sock, timeoutHelper.nextTimeoutChunk(ackTimeout0));
+
+                                onMessageExchanged();
 
                                 if (log.isDebugEnabled())
                                     log.debug("Message has been sent to next node [msg=" + msg +
@@ -4104,9 +4110,12 @@ class ServerImpl extends TcpDiscoveryImpl {
          * Check connection aliveness status.
          */
         private void checkConnection() {
+            Boolean hasRemoteSrvNodes = null;
+
             if (spi.failureDetectionTimeoutEnabled() && !failureThresholdReached &&
-                U.currentTimeMillis() - locNode.lastDataReceivedTime() >= connCheckThreshold &&
-                ring.hasRemoteNodes() && spiStateCopy() == CONNECTED) {
+                U.currentTimeMillis() - locNode.lastExchangeTime() >= connCheckThreshold &&
+                spiStateCopy() == CONNECTED &&
+                (hasRemoteSrvNodes = ring.hasRemoteServerNodes())) {
 
                 log.info("Local node seems to be disconnected from topology (failure detection timeout " +
                     "is reached): [failureDetectionTimeout=" + spi.failureDetectionTimeout() +
@@ -4123,7 +4132,10 @@ class ServerImpl extends TcpDiscoveryImpl {
             if (elapsed > 0)
                 return;
 
-            if (ring.hasRemoteNodes()) {
+            if (hasRemoteSrvNodes == null)
+                hasRemoteSrvNodes = ring.hasRemoteServerNodes();
+
+            if (hasRemoteSrvNodes) {
                 sendMessageAcrossRing(new TcpDiscoveryConnectionCheckMessage(locNode));
 
                 lastTimeConnCheckMsgSent = U.currentTimeMillis();

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
@@ -132,9 +132,9 @@ abstract class TcpDiscoveryImpl {
     }
 
     /**
-     * Called when a chunk of data is received from a remote node.
+     * Called when a local node either received from or sent to a remote node a message.
      */
-    protected void onDataReceived() {
+    protected void onMessageExchanged() {
         // No-op
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -1371,8 +1371,6 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements DiscoverySpi, T
 
             T res = marsh.unmarshal(in == null ? sock.getInputStream() : in, U.gridClassLoader());
 
-            impl.onDataReceived();
-
             return res;
         }
         catch (IOException | IgniteCheckedException e) {
@@ -1413,8 +1411,6 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements DiscoverySpi, T
 
             if (res == -1)
                 throw new EOFException();
-
-            impl.onDataReceived();
 
             return res;
         }

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNode.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNode.java
@@ -89,8 +89,8 @@ public class TcpDiscoveryNode extends GridMetadataAwareAdapter implements Cluste
     @GridToStringExclude
     private volatile long lastUpdateTime = U.currentTimeMillis();
 
-    /** The most recent time when a data chunk was received from a node. */
-    private volatile long lastDataReceivedTime = U.currentTimeMillis();
+    /** The most recent time when node exchanged a message with a remote node. */
+    private volatile long lastExchangeTime = U.currentTimeMillis();
 
     /** Metrics provider (transient). */
     @GridToStringExclude
@@ -393,21 +393,21 @@ public class TcpDiscoveryNode extends GridMetadataAwareAdapter implements Cluste
     }
 
     /**
-     * Gets the last time a node received a data chunk from a remote node.
+     * Gets the last time a node exchanged a message with a remote node.
      *
      * @return Time in milliseconds.
      */
-    public long lastDataReceivedTime() {
-        return lastDataReceivedTime;
+    public long lastExchangeTime() {
+        return lastExchangeTime;
     }
 
     /**
-     * Sets the last time a node receive a data chunk from a remote node in a topology.
+     * Sets the last time a node exchanged a message with a remote node.
      *
-     * @param lastDataReceivedTime Time in milliseconds.
+     * @param lastExchangeTime Time in milliseconds.
      */
-    public void lastDataReceivedTime(long lastDataReceivedTime) {
-        this.lastDataReceivedTime = lastDataReceivedTime;
+    public void lastExchangeTime(long lastExchangeTime) {
+        this.lastExchangeTime = lastExchangeTime;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNodesRing.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNodesRing.java
@@ -152,6 +152,29 @@ public class TcpDiscoveryNodesRing {
     }
 
     /**
+     * Checks whether the topology has remote server nodes in.
+     *
+     * @return {@code true} if the topology has remote server nodes in.
+     */
+    public boolean hasRemoteServerNodes() {
+        rwLock.readLock().lock();
+
+        try {
+            if (nodes.size() < 2)
+                return false;
+
+            for (TcpDiscoveryNode node : nodes)
+                if (!node.isClient() && !node.id().equals(locNode.id()))
+                    return true;
+
+            return false;
+        }
+        finally {
+            rwLock.readLock().unlock();
+        }
+    }
+
+    /**
      * Adds node to topology, also initializes node last update time with current
      * system time.
      *


### PR DESCRIPTION
This warning is printed out when a local server node is considered to be disconnected from the ring - it neither receives message nor sends to the next node.

In the buggy configuration (one server and one client nodes) the server periodically received messages from the client node but unable to send connection check messages to the next node cause there was no any. This affected failure detection timeout implementation logic.

As a fix, the failure should be detected and reported only when there are remote server nodes in a topology and a local node seems to be disconnected from them. To support this "TcpDiscovery.hasRemoteServerNodes()" method was implemented and used by failure timeout logic.